### PR TITLE
chore: add community health files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,14 @@
+# CODEOWNERS — defines default reviewers for pull requests.
+# Edit this file with actual team/owner mappings.
+#
+# Syntax:
+#   <pattern>  @owner1 @owner2
+#
+# Examples:
+#   *                @Specter099
+#   /docs/           @Specter099
+#   *.py             @Specter099
+#   /infrastructure/ @Specter099
+
+# Default: repo owner reviews everything
+*  @Specter099

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Create a report to help us improve
+title: "[Bug] "
+labels: bug
+assignees: ""
+---
+
+## Description
+
+<!-- A clear and concise description of the bug -->
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behaviour
+
+<!-- What you expected to happen -->
+
+## Actual Behaviour
+
+<!-- What actually happened -->
+
+## Environment
+
+- OS:
+- Version / Commit:
+
+## Additional Context
+
+<!-- Logs, screenshots, anything else -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,3 @@
+---
+blank_issues_enabled: true
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature Request
+about: Suggest an idea for this project
+title: "[Feature] "
+labels: feature
+assignees: ""
+---
+
+## Problem
+
+<!-- What problem does this feature solve? -->
+
+## Proposed Solution
+
+<!-- Describe what you want -->
+
+## Alternatives Considered
+
+<!-- Other approaches you thought about -->
+
+## Additional Context
+
+<!-- Mockups, links, prior art -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- Describe the changes and motivation -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Breaking change
+- [ ] Documentation
+- [ ] Chore / maintenance
+
+## Testing
+
+<!-- How did you verify this works? -->
+
+## Checklist
+
+- [ ] Self-reviewed the diff
+- [ ] Added / updated tests
+- [ ] Updated documentation if needed
+- [ ] CI passes

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  # Keep GitHub Actions up to date
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "chore"
+    commit-message:
+      prefix: "chore"
+
+  # Keep Python dependencies up to date
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "chore"
+    commit-message:
+      prefix: "chore"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,6 @@ on:
 jobs:
   ci:
     uses: Specter099/.github/.github/workflows/python-ci.yml@main
+    with:
+      install-command: "pip install -r requirements-dev.txt"
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  ci:
+    uses: Specter099/.github/.github/workflows/python-ci.yml@main
+    secrets: inherit

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,86 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by contacting [@Specter099](https://github.com/Specter099) via GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1,
+available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thank you for your interest in contributing to **repo-health-dashboard**!
+
+## Getting Started
+
+1. **Fork** the repository and clone your fork
+2. Create a feature branch:
+   ```bash
+   git checkout -b feature/your-feature
+   ```
+3. Make your changes
+4. Commit using [Conventional Commits](https://www.conventionalcommits.org/):
+   ```
+   feat: add new widget
+   fix: handle nil pointer in parser
+   chore: update CI action versions
+   ```
+5. Push and **open a Pull Request** against `main`
+
+## Code Style
+
+- Follow existing patterns in the codebase
+- Keep PRs focused and small
+- Write tests for non-trivial changes
+
+## Pull Request Guidelines
+
+- Fill out the PR template completely
+- Link any related issues (`Closes #123`)
+- Ensure CI passes before requesting review
+- Address review feedback promptly

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Please do not open a public issue for security vulnerabilities.**
+
+Report security issues privately via
+[GitHub's private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability)
+or by emailing the maintainers directly.
+
+We will:
+1. Acknowledge the report within **48 hours**
+2. Investigate and keep you updated on progress
+3. Credit you in the fix (unless you prefer otherwise)
+
+Thank you for helping keep this project secure.

--- a/collect_metrics.py
+++ b/collect_metrics.py
@@ -15,12 +15,8 @@ import requests  # type: ignore[import-untyped]
 from dateutil import parser as dateparser  # type: ignore[import-untyped]
 
 GITHUB_TOKEN = os.environ.get("GITHUB_TOKEN", "")
-if not GITHUB_TOKEN:
-    print("ERROR: GITHUB_TOKEN environment variable is required", file=sys.stderr)
-    sys.exit(1)
 USERNAME = os.environ.get("GITHUB_USERNAME", "Specter099")
 OUTPUT_DIR = Path("dist")
-OUTPUT_DIR.mkdir(exist_ok=True)
 
 HEADERS = {
     "Authorization": f"Bearer {GITHUB_TOKEN}",
@@ -216,6 +212,11 @@ def compute_health_score(repo: dict) -> int:
 
 
 def main():
+    if not GITHUB_TOKEN:
+        print("ERROR: GITHUB_TOKEN environment variable is required", file=sys.stderr)
+        sys.exit(1)
+    OUTPUT_DIR.mkdir(exist_ok=True)
+
     print(f"Collecting metrics for {USERNAME}...", flush=True)
 
     repos = paginate(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+ruff
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/tests/test_health_score.py
+++ b/tests/test_health_score.py
@@ -1,0 +1,39 @@
+from collect_metrics import compute_health_score
+
+
+def _base_repo(**overrides):
+    defaults = {
+        "stale_branch_count": 0,
+        "open_pr_count": 0,
+        "branch_protection": True,
+        "has_license": True,
+        "has_description": True,
+        "dependabot_alerts": 0,
+        "staleness": "fresh",
+    }
+    defaults.update(overrides)
+    return defaults
+
+
+def test_perfect_score():
+    assert compute_health_score(_base_repo()) == 100
+
+
+def test_no_branch_protection():
+    assert compute_health_score(_base_repo(branch_protection=False)) == 90
+
+
+def test_stale_branches_capped():
+    # 10 stale branches * 5 = 50, but capped at 20
+    assert compute_health_score(_base_repo(stale_branch_count=10)) == 80
+
+
+def test_multiple_deductions():
+    repo = _base_repo(
+        branch_protection=False,
+        has_license=False,
+        has_description=False,
+        open_pr_count=3,
+    )
+    # -10 (protection) -5 (license) -3 (description) -9 (3 PRs * 3)
+    assert compute_health_score(repo) == 73


### PR DESCRIPTION
## Summary

Bootstraps the repository with standard community health files.

## Files Added

- `.github/CODEOWNERS`
- `.github/ISSUE_TEMPLATE/bug_report.md`
- `.github/ISSUE_TEMPLATE/config.yml`
- `.github/ISSUE_TEMPLATE/feature_request.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `.github/dependabot.yml`
- `.github/workflows/ci.yml`
- `CODE_OF_CONDUCT.md`
- `CONTRIBUTING.md`
- `SECURITY.md`

### Notes

- **dependabot.yml** was auto-generated based on detected project ecosystems
- **CODEOWNERS** needs to be edited with actual team/owner mappings
- Review all generated files and adjust to your project's needs

---
Generated by `bootstrap-repo.sh`