### PR TITLE
chore: remove CI workaround, fix CloudFront condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,4 @@ on:
 jobs:
   ci:
     uses: Specter099/.github/.github/workflows/python-ci.yml@main
-    with:
-      install-command: "pip install -r requirements-dev.txt"
     secrets: inherit

--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -125,9 +125,9 @@ jobs:
           echo "S3 deployment complete: https://${BUCKET}.s3-website-us-east-1.amazonaws.com"
 
       - name: Invalidate CloudFront (if configured)
-        if: secrets.CLOUDFRONT_DISTRIBUTION_ID != ''
         env:
           CF_DIST: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
+        if: env.CF_DIST != ''
         run: |
           aws cloudfront create-invalidation \
             --distribution-id "$CF_DIST" \


### PR DESCRIPTION
## Summary
- Remove `install-command` workaround from `ci.yml` — the upstream `python-ci` reusable workflow now handles empty defaults correctly (Specter099/.github#21)
- Fix `dashboard.yml` CloudFront invalidation step — `secrets.*` can't be used in `if:` conditions directly; moved to `env:` var and check `env.CF_DIST` instead

## Test plan
- [ ] CI passes without the `install-command` override
- [ ] Dashboard workflow still syntactically valid (CloudFront step conditional on secret being set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)