### PR TITLE
feat: add CDK infrastructure for static site hosting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
+cdk.out/
 __pycache__/
 *.pyc
 .venv/

--- a/app.py
+++ b/app.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+from pathlib import Path
+
+import aws_cdk as cdk
+from specter_static_site import StaticSiteStack
+
+app = cdk.App()
+
+dist_path = str(Path(__file__).parent / "dist")
+
+StaticSiteStack(
+    app,
+    "RepoHealthDashboard",
+    domain_name="github-health.thelauerfam.com",
+    dist_path=dist_path,
+    hosted_zone_id="Z03182223J9MCRROVG2FB",
+    dashboard_name="repo-health",
+    env=cdk.Environment(
+        account="451645558365",
+        region="us-east-1",
+    ),
+)
+
+app.synth()

--- a/cdk.json
+++ b/cdk.json
@@ -1,0 +1,6 @@
+{
+  "app": "python3 app.py",
+  "context": {
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true
+  }
+}

--- a/requirements-cdk.txt
+++ b/requirements-cdk.txt
@@ -1,0 +1,4 @@
+aws-cdk-lib~=2.208.0
+constructs>=10.0.0,<11.0.0
+cdk-nag>=2.0.0
+specter-static-site @ git+https://github.com/Specter099/static-site-infra.git@main


### PR DESCRIPTION
## Summary
- Add CDK app (`app.py`) using `specter-static-site` construct
- Deploys `github-health.thelauerfam.com` with S3 + CloudFront + ACM cert + CloudWatch
- Stack already deployed to production account `451645558365`

## Resources created
- S3 bucket: `github-health-thelauerfam-com-site-451645558365-us-east-1-an`
- CloudFront: `d1qiokl5yhxapk.cloudfront.net`
- ACM certificate (DNS-validated via Route 53)
- CloudWatch dashboard: `repo-health`
- CloudWatch alarms: 5xx and 4xx error rates

## Remaining
- DNS record for `github-health.thelauerfam.com` → CloudFront (in route53-cdk repo)
- Generate real dashboard content via workflow dispatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)