### PR TITLE
fix: add production environment to S3 deploy job

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -99,6 +99,10 @@ jobs:
       github.event.inputs.deploy_target == 'both' ||
       github.event.inputs.deploy_target == 's3'
     runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+      contents: read
 
     steps:
       - name: Download artifact


### PR DESCRIPTION
## Summary
Add `environment: production` and `permissions: id-token: write` to the `deploy-s3` job so it can access the AWS secrets and assume the OIDC role.

## Secrets configured
- `AWS_DEPLOY_ROLE_ARN` → `arn:aws:iam::451645558365:role/github-actions-role`
- `DASHBOARD_BUCKET` → `github-health-thelauerfam-com-site-451645558365-us-east-1-an`
- `CLOUDFRONT_DISTRIBUTION_ID` → `E3H2L46DBDXM3L`

## Test plan
- [ ] After merge, trigger: `gh workflow run dashboard.yml -f deploy_target=s3`
- [ ] Verify https://github-health.thelauerfam.com loads the dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)