### PR TITLE
fix: make CloudFront invalidation non-fatal

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -129,6 +129,7 @@ jobs:
           echo "S3 deployment complete: https://${BUCKET}.s3-website-us-east-1.amazonaws.com"
 
       - name: Invalidate CloudFront (if configured)
+        continue-on-error: true
         env:
           CF_DIST: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
         if: env.CF_DIST != ''


### PR DESCRIPTION
## Summary
Add `continue-on-error: true` to the CloudFront invalidation step. The `github-actions-role` doesn't have `cloudfront:CreateInvalidation` permission, so the step fails. Content still refreshes after the 5-min CloudFront TTL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)