### PR TITLE
feat: grant github-actions-role access to site bucket via CDK

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ StaticSiteStack(
     dist_path=dist_path,
     hosted_zone_id="Z03182223J9MCRROVG2FB",
     dashboard_name="repo-health",
+    deploy_role_arns=["arn:aws:iam::451645558365:role/github-actions-role"],
     env=cdk.Environment(
         account="451645558365",
         region="us-east-1",


### PR DESCRIPTION
## Summary
Pass `deploy_role_arns` to `StaticSiteStack` so CDK manages the `github-actions-role` S3 permissions. This prevents future `cdk deploy` runs from overwriting the manually added bucket policy.

Stack already deployed to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)