### PR TITLE
fix: use GH_PAT for repo metrics collection

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Collect repo metrics
         id: collect
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
           GITHUB_USERNAME: Specter099
         run: python collect_metrics.py
 


### PR DESCRIPTION
## Summary
Use `GH_PAT` (fine-grained PAT with read access to all repos) instead of the default `GITHUB_TOKEN` which is scoped to this repo only.

## Test plan
- [ ] After merge, trigger `gh workflow run dashboard.yml -f deploy_target=s3`
- [ ] Dashboard shows all Specter099 repos with health scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)