### PR TITLE
fix: handle 403 responses gracefully in metrics collector

### DIFF
--- a/collect_metrics.py
+++ b/collect_metrics.py
@@ -30,7 +30,7 @@ SKIP_REPOS: set[str] = set()  # add repo names here to exclude
 
 def gh_get(url: str, params: dict | None = None) -> dict | list:
     r = requests.get(url, headers=HEADERS, params=params, timeout=15)
-    if r.status_code == 404:
+    if r.status_code in (403, 404):
         return {}
     r.raise_for_status()
     return r.json()


### PR DESCRIPTION
## Summary
Treat HTTP 403 the same as 404 in `gh_get()` — return empty data instead of raising an exception. The PAT lacks `Administration` permission to read branch protection, causing every repo to fail.

## Test plan
- [ ] After merge, trigger `gh workflow run dashboard.yml -f deploy_target=s3`
- [ ] Dashboard shows all repos with health scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)