### PR TITLE
fix: correct logout button path to /_signout

### DIFF
--- a/build_dashboard.py
+++ b/build_dashboard.py
@@ -473,7 +473,7 @@ html = f"""<!DOCTYPE html>
   </div>
   <div class="header-right">
     <div class="generated">Generated {generated_at}</div>
-    <a href="/logout" class="logout-btn">Logout</a>
+    <a href="/_signout" class="logout-btn">Logout</a>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- The logout button linked to `/logout` instead of `/_signout`
- The Lambda@Edge auth handler only intercepts `/_signout` — hitting `/logout` passed through unauthenticated, CloudFront served `index.html`, and the user remained logged in
- One-line fix: `href="/logout"` → `href="/_signout"`

## Test plan
- [ ] Rebuild dashboard (`python3 build_dashboard.py`) and deploy to S3
- [ ] Click Logout — should clear auth cookies and redirect to Cognito logout endpoint
- [ ] Verify you are redirected to the Cognito login page after logout

🤖 Generated with [Claude Code](https://claude.com/claude-code)